### PR TITLE
Include black and aiohttp as dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ Tatsu = "pytatsu.__main__:cli"
 [tool.poetry.dependencies]
 python = "^3.9"
 pybmtool = "^0.1.2"
+aiohttp = "^3.8.0"
 
 [tool.poetry.dev-dependencies]
+black = "^22.8.0"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/Cryptiiiic/Tatsu/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ Tatsu = "pytatsu.__main__:cli"
 [tool.poetry.dependencies]
 python = "^3.9"
 pybmtool = "^0.1.2"
-aiohttp = "^3.8.0"
+aiohttp = "^3.8.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.8.0"


### PR DESCRIPTION
This small PR adds `black` as a developer dependency, while also adding `aiohttp` as a package dependency, since I ran across that missing package.