### PR TITLE
Rename functions to be more pythonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# pytatsu 
-## A Python library/CLI tool for requesting and saving shsh blobs from apple's tatsu signing server api.
+# pytatsu
+
+## A Python library/CLI tool for requesting and saving SHSH blobs from Apple's Tatsu signing server API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pytatsu"
 version = "0.1.1"
-description = "A Python library/CLI tool for requesting and saving shsh blobs from apple's tatsu signing server api."
+description = "A Python library/CLI tool for requesting and saving SHSH blobs from Apple's Tatsu signing server API."
 authors = ["Cryptiiiic <liamwqs@gmail.com>"]
 license = "lgpl-3.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ packages = [
 ]
 
 [tool.poetry.scripts]
-Tatsu = "pytatsu.__main__:cli"
+tatsu = "pytatsu.__main__:cli"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pytatsu/__init__.py
+++ b/pytatsu/__init__.py
@@ -1,3 +1,5 @@
+from .tss import TSS
+
 try:
     from importlib.metadata import version
 except ModuleNotFoundError:

--- a/pytatsu/__main__.py
+++ b/pytatsu/__main__.py
@@ -1,9 +1,9 @@
-from pytatsu.tss import TSS
+import pytatsu
 import os
 
 
 def cli():
-    tss = TSS(
+    tss = pytatsu.TSS(
         board="d63ap",
         update=False,
         ecid=0x69,

--- a/pytatsu/__main__.py
+++ b/pytatsu/__main__.py
@@ -5,17 +5,17 @@ import os
 def cli():
     tss = pytatsu.TSS(
         board="d63ap",
-        update=False,
         ecid=0x69,
+        update=False,
         generator="0x1111111111111111",
         apnonce="",
         sepnonce="",
-        buildManifestPath=f"{os.getcwd()}/BuildManifest.plist",
-        componentList=[
+        build_manifest_path=f"{os.getcwd()}/BuildManifest.plist",
+        component_list=[
             "Rap,RTKitOS",
         ],
     )
-    tss.tatsuRequestSend()
+    tss.send_request()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR renames `pytatsu`'s functions to be more pythonic; using `pytatsu.TSS.tatsuSendRequest` over `pytatsu.TSS.send_request` is much more pythonic, as functions follow a specific set of rules (likely detailed in PEP8) that make them feel less like you're working with a Java API wrapper.

I've also made imports shorter; you can now just import `pytatsu` rather than having to do it another way, which is much cleaner. Finally, bins (or scripts) are often named in lowercase, which is something I've done here as well.